### PR TITLE
Parallel file sync with rate limit retries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,6 @@ COPY src/ ./src/
 RUN --mount=type=cache,target=/root/.cache \
     uv sync --locked --no-dev
 
-RUN uv build && uv pip install --system dist/nogisync-*.whl
+ENV PATH="/code/.venv/bin:$PATH"
 
 CMD ["nogisync", "--help"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = "~=3.14.0"
 version = "1.0.0"
 dependencies = [
     "notion-client>=3,<4",
-    "frontmatter>=3,<4",
+    "pyyaml>=5.4,<7",
     "click>=8,<9",
     "stamina>=25.2,<26",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,10 +5,10 @@ authors = [{ name = "Fencer Inc", email = "hello@fencer.dev" }]
 requires-python = "~=3.14.0"
 version = "1.0.0"
 dependencies = [
-    "notion-client",
-    "frontmatter",
-    "click",
-    "stamina>=25.2.0",
+    "notion-client>=3,<4",
+    "frontmatter>=3,<4",
+    "click>=8,<9",
+    "stamina>=25.2,<26",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ version = "1.0.0"
 dependencies = [
     "notion-client",
     "frontmatter",
-    "click"
+    "click",
+    "stamina>=25.2.0",
 ]
 
 [project.scripts]

--- a/src/nogisync/cli.py
+++ b/src/nogisync/cli.py
@@ -1,4 +1,6 @@
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import click
@@ -11,29 +13,87 @@ from nogisync.provenance import ProvenanceConfig
 logger = logging.getLogger(__name__)
 
 
-def process_page_hierarchy(client, base_parent_id: str, relative_path: Path) -> str:
-    """Creates/updates page hierarchy based on directory structure"""
+def process_page_hierarchy(
+    client,
+    base_parent_id: str,
+    relative_path: Path,
+    hierarchy_cache: dict[str, str] | None = None,
+) -> str:
+    """Creates/updates page hierarchy based on directory structure.
+
+    Uses hierarchy_cache to avoid redundant API lookups when multiple files
+    share the same parent directories.
+    """
+    if hierarchy_cache is None:
+        hierarchy_cache = {}
+
     current_parent_id = base_parent_id
     path_parts = relative_path.parts[:-1]  # Exclude the markdown file itself
 
-    for part in path_parts:
-        # Convert directory name to title case (e.g., "foo_lives_here" -> "Foo Lives Here")
-        page_title = " ".join(word.capitalize() for word in part.replace("-", "_").split("_"))
+    for i, part in enumerate(path_parts):
+        cache_key = "/".join(path_parts[: i + 1])
+        if cache_key in hierarchy_cache:
+            current_parent_id = hierarchy_cache[cache_key]
+            continue
 
-        # Check if page exists under current parent
+        page_title = " ".join(word.capitalize() for word in part.replace("-", "_").split("_"))
         existing_page = notion.find_notion_page(client, page_title, parent_id=current_parent_id)
 
         if existing_page:
             current_parent_id = existing_page["id"]
         else:
-            # Create new parent page
             new_page = notion.create_notion_page(client, current_parent_id, page_title, "")
             if new_page:
                 current_parent_id = new_page["id"]
             else:
                 raise Exception(f"Failed to create new parent page: {page_title}")
 
+        hierarchy_cache[cache_key] = current_parent_id
+
     return current_parent_id
+
+
+def sync_file(
+    client,
+    md_file: Path,
+    path: Path,
+    parent_page_id: str,
+    provenance: bool,
+    provenance_source_url: str | None,
+    provenance_timestamp: bool,
+) -> None:
+    """Sync a single markdown file to Notion."""
+    relative_path = md_file.relative_to(path)
+    start = time.monotonic()
+    logger.info("Started syncing %s", relative_path)
+
+    try:
+        post = Frontmatter.read_file(md_file)
+    except yaml.YAMLError:
+        logger.info("No valid frontmatter in %s, treating as plain markdown", md_file.name)
+        post = {}
+
+    title = get_title(md_file, post)
+    content = get_content(md_file, post)
+
+    provenance_config = ProvenanceConfig.from_environment(
+        enabled=provenance,
+        source_url=provenance_source_url,
+        include_timestamp=provenance_timestamp,
+        file_path=str(relative_path),
+    )
+
+    existing_page = notion.find_notion_page(client, title, parent_id=parent_page_id)
+
+    if existing_page:
+        logger.info("Updating existing page: %s", title)
+        notion.update_notion_page(client, existing_page["id"], content, provenance_config)
+    else:
+        logger.info("Creating new page: %s", title)
+        notion.create_notion_page(client, parent_page_id, title, content, provenance_config)
+
+    elapsed = time.monotonic() - start
+    logger.info("Finished syncing %s (%.1fs)", relative_path, elapsed)
 
 
 @click.command()
@@ -61,6 +121,13 @@ def process_page_hierarchy(client, base_parent_id: str, relative_path: Path) -> 
     default=True,
     help="Include sync timestamp in provenance (default: enabled)",
 )
+@click.option(
+    "--workers",
+    "-w",
+    type=int,
+    default=4,
+    help="Number of parallel workers (default: 4)",
+)
 def main(
     token: str,
     parent_page_id: str,
@@ -68,50 +135,58 @@ def main(
     provenance: bool,
     provenance_source_url: str | None,
     provenance_timestamp: bool,
+    workers: int,
 ) -> None:
     """
     Sync GitHub markdown files to Notion
     """
-    # Use rglob to recursively find all markdown files
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
     markdown_files = list(Path(path).rglob("*.md"))
+    logger.info("Found %d markdown files to sync", len(markdown_files))
+    start = time.monotonic()
 
+    client = notion.get_notion_client(token)
+
+    # Pre-resolve directory hierarchies sequentially (they depend on parent IDs)
+    hierarchy_cache: dict[str, str] = {}
     for md_file in markdown_files:
-        # Get relative path from source directory
         relative_path = md_file.relative_to(path)
+        process_page_hierarchy(client, parent_page_id, relative_path, hierarchy_cache)
 
-        # Read the markdown file
-        try:
-            post = Frontmatter.read_file(md_file)
-        except yaml.YAMLError:
-            logger.info("No valid frontmatter in %s, treating as plain markdown", md_file.name)
-            post = {}
-        title = get_title(md_file, post)
-        content = get_content(md_file, post)
+    # Build a map of each file to its resolved parent page ID
+    file_parent_ids: dict[Path, str] = {}
+    for md_file in markdown_files:
+        relative_path = md_file.relative_to(path)
+        dir_key = str(relative_path.parent)
+        file_parent_ids[md_file] = hierarchy_cache.get(dir_key, parent_page_id)
 
-        print(f"Processing {relative_path}...")
+    # Sync files in parallel
+    failed = []
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {
+            executor.submit(
+                sync_file,
+                client,
+                md_file,
+                path,
+                file_parent_ids[md_file],
+                provenance,
+                provenance_source_url,
+                provenance_timestamp,
+            ): md_file
+            for md_file in markdown_files
+        }
+        for future in as_completed(futures):
+            md_file = futures[future]
+            try:
+                future.result()
+            except Exception:
+                logger.exception("Failed to sync %s", md_file.relative_to(path))
+                failed.append(md_file)
 
-        client = notion.get_notion_client(token)
-
-        # Process directory hierarchy and get the immediate parent page ID
-        immediate_parent_id = process_page_hierarchy(client, parent_page_id, relative_path)
-
-        # Create provenance config for this file
-        provenance_config = ProvenanceConfig.from_environment(
-            enabled=provenance,
-            source_url=provenance_source_url,
-            include_timestamp=provenance_timestamp,
-            file_path=str(relative_path),
-        )
-
-        # Check if page exists under its immediate parent
-        existing_page = notion.find_notion_page(client, title, parent_id=immediate_parent_id)
-
-        if existing_page:
-            print(f"Updating existing page: {title}")
-            notion.update_notion_page(client, existing_page["id"], content, provenance_config)
-        else:
-            print(f"Creating new page: {title}")
-            notion.create_notion_page(client, immediate_parent_id, title, content, provenance_config)
+    elapsed = time.monotonic() - start
+    logger.info("Sync complete: %d files in %.1fs (%d failed)", len(markdown_files), elapsed, len(failed))
 
 
 def get_content(md_file: Path, post: dict) -> str:

--- a/src/nogisync/cli.py
+++ b/src/nogisync/cli.py
@@ -1,11 +1,11 @@
 import logging
+import re
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import click
 import yaml
-from frontmatter import Frontmatter
 
 from nogisync import notion
 from nogisync.provenance import ProvenanceConfig
@@ -68,7 +68,7 @@ def sync_file(
     logger.info("Started syncing %s", relative_path)
 
     try:
-        post = Frontmatter.read_file(md_file)
+        post = read_frontmatter(md_file)
     except yaml.YAMLError:
         logger.info("No valid frontmatter in %s, treating as plain markdown", md_file.name)
         post = {}
@@ -187,6 +187,21 @@ def main(
 
     elapsed = time.monotonic() - start
     logger.info("Sync complete: %d files in %.1fs (%d failed)", len(markdown_files), elapsed, len(failed))
+
+
+_FRONTMATTER_RE = re.compile(r"^\s*(?:---|\+\+\+)(.*?)(?:---|\+\+\+)\s*(.+)$", re.DOTALL)
+
+
+def read_frontmatter(path: Path) -> dict:
+    """Read a markdown file and split YAML frontmatter from body."""
+    text = path.read_text(encoding="utf-8")
+    match = _FRONTMATTER_RE.search(text)
+    if not match:
+        return {"attributes": None, "body": text}
+    return {
+        "attributes": yaml.load(match.group(1), Loader=yaml.SafeLoader),
+        "body": match.group(2),
+    }
 
 
 def get_content(md_file: Path, post: dict) -> str:

--- a/src/nogisync/markdown.py
+++ b/src/nogisync/markdown.py
@@ -1,6 +1,103 @@
 import re
 
 NOTION_CONTENT_MAX_LENGTH = 2000
+# Notion API rejects list nesting beyond 3 levels
+NOTION_MAX_LIST_DEPTH = 3
+
+NOTION_SUPPORTED_LANGUAGES = frozenset(
+    {
+        "abap",
+        "abc",
+        "agda",
+        "arduino",
+        "ascii art",
+        "assembly",
+        "bash",
+        "basic",
+        "bnf",
+        "c",
+        "c#",
+        "c++",
+        "clojure",
+        "coffeescript",
+        "coq",
+        "css",
+        "dart",
+        "dhall",
+        "diff",
+        "docker",
+        "ebnf",
+        "elixir",
+        "elm",
+        "erlang",
+        "f#",
+        "flow",
+        "fortran",
+        "gherkin",
+        "glsl",
+        "go",
+        "graphql",
+        "groovy",
+        "haskell",
+        "hcl",
+        "html",
+        "idris",
+        "java",
+        "javascript",
+        "json",
+        "julia",
+        "kotlin",
+        "latex",
+        "less",
+        "lisp",
+        "livescript",
+        "llvm ir",
+        "lua",
+        "makefile",
+        "markdown",
+        "markup",
+        "matlab",
+        "mathematica",
+        "mermaid",
+        "nix",
+        "notion formula",
+        "objective-c",
+        "ocaml",
+        "pascal",
+        "perl",
+        "php",
+        "plain text",
+        "powershell",
+        "prolog",
+        "protobuf",
+        "purescript",
+        "python",
+        "r",
+        "racket",
+        "reason",
+        "ruby",
+        "rust",
+        "sass",
+        "scala",
+        "scheme",
+        "scss",
+        "shell",
+        "smalltalk",
+        "solidity",
+        "sql",
+        "swift",
+        "toml",
+        "typescript",
+        "vb.net",
+        "verilog",
+        "vhdl",
+        "visual basic",
+        "webassembly",
+        "xml",
+        "yaml",
+        "java/c/c++/c#",
+    }
+)
 
 
 def replace_part(parts, pattern, replace_function) -> list:
@@ -247,7 +344,10 @@ def parse_markdown_to_notion_blocks(markdown) -> list[dict]:
     def replace_code_blocks(match) -> str:
         index = len(code_blocks)
         language, content = match.group(1), match.group(2)
-        code_blocks[index] = (language or "plain text").strip(), content.strip()
+        language = (language or "plain text").strip().lower()
+        if language not in NOTION_SUPPORTED_LANGUAGES:
+            language = "plain text"
+        code_blocks[index] = language, content.strip()
         return f"CODE_BLOCK_{index}"
 
     # Replace code blocks with placeholders
@@ -316,8 +416,8 @@ def parse_markdown_to_notion_blocks(markdown) -> list[dict]:
                 stack.pop()
                 current_indent -= 1
 
-            if indent == current_indent:
-                # Same level of indentation, add to the current level of the stack
+            if indent == current_indent or len(stack) >= NOTION_MAX_LIST_DEPTH:
+                # Same level, or Notion max nesting depth reached — append at current level
                 stack[-1].append(item)
             else:  # indent > current_indent
                 # Nested item, add it as a child of the previous item
@@ -362,8 +462,8 @@ def parse_markdown_to_notion_blocks(markdown) -> list[dict]:
                 stack.pop()
                 current_indent -= 1
 
-            if indent == current_indent:
-                # Same level of indentation, add to the current level of the stack
+            if indent == current_indent or len(stack) >= NOTION_MAX_LIST_DEPTH:
+                # Same level, or Notion max nesting depth reached — append at current level
                 stack[-1].append(item)
             else:  # indent > current_indent
                 # Nested item, add it as a child of the previous item
@@ -473,21 +573,32 @@ def parse_markdown_to_notion_blocks(markdown) -> list[dict]:
             latex_content = latex_blocks[latex_block_index]
             blocks.append({"type": "equation", "equation": {"expression": latex_content}})
 
-        # Image blocks
+        # Image blocks — Notion only accepts absolute HTTP(S) URLs
         elif image_match:
-            block: dict = {
-                "object": "block",
-                "type": "image",
-                "image": {
-                    "external": {
-                        "url": image_match.group(2),
+            image_url = image_match.group(2)
+            if image_url.startswith(("http://", "https://")):
+                block: dict = {
+                    "object": "block",
+                    "type": "image",
+                    "image": {
+                        "external": {
+                            "url": image_url,
+                        }
+                    },
+                }
+                caption = image_match.group(1)
+                if caption:
+                    block["image"]["caption"] = [{"type": "text", "text": {"content": caption, "link": None}}]
+                blocks.append(block)
+            else:
+                # Relative/invalid URLs can't be used — render as a text paragraph
+                blocks.append(
+                    {
+                        "object": "block",
+                        "type": "paragraph",
+                        "paragraph": {"rich_text": process_inline_formatting(line)},
                     }
-                },
-            }
-            caption = image_match.group(1)
-            if caption:
-                block["image"]["caption"] = [{"type": "text", "text": {"content": caption, "link": None}}]
-            blocks.append(block)
+                )
 
         # Create paragraph blocks for other lines
         elif line.strip():

--- a/src/nogisync/notion.py
+++ b/src/nogisync/notion.py
@@ -2,11 +2,17 @@ import logging
 from typing import cast
 
 import notion_client
+import stamina
 
 from nogisync.markdown import parse_md
 from nogisync.provenance import ProvenanceConfig, create_provenance_block
 
 logger = logging.getLogger(__name__)
+
+
+def _is_rate_limited(error: Exception) -> bool:
+    """Check if the error is a Notion API rate limit (429) response."""
+    return isinstance(error, notion_client.errors.APIResponseError) and error.status == 429
 
 
 def get_notion_client(token: str) -> notion_client.Client:
@@ -20,6 +26,7 @@ def get_notion_parent_page(client: notion_client.Client, parent_page_id: str) ->
     return results[0] if results else None
 
 
+@stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)
 def find_notion_page(client: notion_client.Client, title: str, parent_id: str | None = None) -> dict | None:
     """Find a Notion page by its title."""
     response = cast(dict, client.search(query=title, filter={"value": "page", "property": "object"}))
@@ -38,6 +45,7 @@ def find_notion_page(client: notion_client.Client, title: str, parent_id: str | 
     return None
 
 
+@stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)
 def create_notion_page(
     client: notion_client.Client,
     parent_page_id: str,
@@ -49,13 +57,13 @@ def create_notion_page(
     try:
         blocks = parse_md(content)
 
-        # Prepend provenance block if enabled and content is non-empty
         if provenance_config and content:
             provenance_block = create_provenance_block(provenance_config)
-            if provenance_block:
+            # create_provenance_block always returns a block when config is enabled,
+            # so the None branch is not reachable in practice
+            if provenance_block:  # pragma: no branch
                 blocks = [provenance_block] + blocks
 
-        # Create the page
         new_page = cast(
             dict,
             client.pages.create(
@@ -65,7 +73,6 @@ def create_notion_page(
             ),
         )
 
-        # Add the blocks to the page
         while len(blocks) > 100:
             client.blocks.children.append(block_id=new_page["id"], children=blocks[:100])
             blocks = blocks[100:]
@@ -74,10 +81,13 @@ def create_notion_page(
 
         return cast(dict, new_page)
     except notion_client.errors.APIResponseError as e:
+        if e.status == 429:
+            raise
         logger.error(e)
         return {}
 
 
+@stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)
 def update_notion_page(
     client: notion_client.Client,
     page_id: str,
@@ -88,7 +98,6 @@ def update_notion_page(
     try:
         blocks = parse_md(content)
 
-        # Prepend provenance block if enabled and content is non-empty
         if provenance_config and content:
             provenance_block = create_provenance_block(provenance_config)
             # create_provenance_block always returns a block when config is enabled,
@@ -96,16 +105,16 @@ def update_notion_page(
             if provenance_block:  # pragma: no branch
                 blocks = [provenance_block] + blocks
 
-        # First, delete existing blocks
         existing_blocks = cast(dict, client.blocks.children.list(block_id=page_id)).get("results", [])
         for block in existing_blocks:
             client.blocks.delete(block_id=block["id"])
 
-        # Then add new blocks
         while len(blocks) > 100:
             client.blocks.children.append(block_id=page_id, children=blocks[:100])
             blocks = blocks[100:]
 
         client.blocks.children.append(block_id=page_id, children=blocks)
     except notion_client.errors.APIResponseError as e:
+        if e.status == 429:
+            raise
         logger.error(e)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from nogisync.cli import get_content, get_title, main, process_page_hierarchy
+from nogisync.cli import get_content, get_title, main, process_page_hierarchy, sync_file
 
 
 class TestGetTitle(TestCase):
@@ -81,45 +81,66 @@ class TestProcessPageHierarchy(TestCase):
         with self.assertRaises(Exception, msg="Failed to create new parent page: Dir1"):
             process_page_hierarchy(None, "base_id", Path("dir1/file.md"))
 
+    @patch("nogisync.notion.find_notion_page")
+    def test_uses_cache(self, mock_find_page):
+        mock_find_page.side_effect = lambda client, title, parent_id: {"id": f"existing_{title}"}
+        cache: dict[str, str] = {}
 
-class TestMain(TestCase):
+        process_page_hierarchy(None, "base_id", Path("dir1/file1.md"), cache)
+        self.assertEqual(mock_find_page.call_count, 1)
+
+        process_page_hierarchy(None, "base_id", Path("dir1/file2.md"), cache)
+        self.assertEqual(mock_find_page.call_count, 1)
+
+
+class TestSyncFile(TestCase):
     @patch("nogisync.cli.notion")
     @patch("nogisync.cli.Frontmatter")
     def test_creates_new_page(self, mock_frontmatter, mock_notion):
-        runner = CliRunner()
-        mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
         mock_frontmatter.read_file.return_value = {
             "attributes": {"title": "Test Doc"},
-            "body": "# Hello\nContent here",
+            "body": "Content",
         }
 
-        with runner.isolated_filesystem():
+        with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
-            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\n# Hello\nContent here")
-            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            sync_file(
+                MagicMock(),
+                Path("docs/test.md"),
+                Path("docs"),
+                "parent-id",
+                True,
+                None,
+                True,
+            )
 
-        self.assertEqual(result.exit_code, 0)
         mock_notion.create_notion_page.assert_called_once()
 
     @patch("nogisync.cli.notion")
     @patch("nogisync.cli.Frontmatter")
     def test_updates_existing_page(self, mock_frontmatter, mock_notion):
-        runner = CliRunner()
-        mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = {"id": "existing-page"}
         mock_frontmatter.read_file.return_value = {
             "attributes": {"title": "Test Doc"},
             "body": "Updated content",
         }
 
-        with runner.isolated_filesystem():
+        with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nUpdated content")
-            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
+            sync_file(
+                MagicMock(),
+                Path("docs/test.md"),
+                Path("docs"),
+                "parent-id",
+                True,
+                None,
+                True,
+            )
 
-        self.assertEqual(result.exit_code, 0)
         mock_notion.update_notion_page.assert_called_once()
 
     @patch("nogisync.cli.notion")
@@ -127,19 +148,64 @@ class TestMain(TestCase):
     def test_handles_yaml_error(self, mock_frontmatter, mock_notion):
         import yaml
 
-        runner = CliRunner()
-        mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
         mock_frontmatter.read_file.side_effect = yaml.YAMLError("bad yaml")
 
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("# No frontmatter")
+            sync_file(
+                MagicMock(),
+                Path("docs/test.md"),
+                Path("docs"),
+                "parent-id",
+                True,
+                None,
+                True,
+            )
+
+        mock_notion.create_notion_page.assert_called_once()
+
+
+class TestMainFailure(TestCase):
+    @patch("nogisync.cli.sync_file", side_effect=RuntimeError("API down"))
+    @patch("nogisync.cli.process_page_hierarchy")
+    @patch("nogisync.cli.notion")
+    def test_logs_and_reports_sync_failures(self, mock_notion, mock_hierarchy, mock_sync):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+
         with runner.isolated_filesystem():
             Path("docs").mkdir()
-            Path("docs/test.md").write_text("# No frontmatter\nJust content")
+            Path("docs/test.md").write_text("content")
             result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_notion.create_notion_page.assert_called_once()
+        mock_sync.assert_called_once()
+
+
+class TestMain(TestCase):
+    @patch("nogisync.cli.notion")
+    @patch("nogisync.cli.Frontmatter")
+    def test_syncs_files_in_parallel(self, mock_frontmatter, mock_notion):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+        mock_frontmatter.read_file.return_value = {
+            "attributes": {"title": "Test Doc"},
+            "body": "Content",
+        }
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/a.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            Path("docs/b.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(mock_notion.create_notion_page.call_count, 2)
 
     @patch("nogisync.cli.notion")
     @patch("nogisync.cli.Frontmatter")
@@ -178,5 +244,24 @@ class TestMain(TestCase):
             result = runner.invoke(
                 main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs", "--no-provenance"]
             )
+
+        self.assertEqual(result.exit_code, 0)
+
+    @patch("nogisync.cli.notion")
+    @patch("nogisync.cli.Frontmatter")
+    def test_custom_workers(self, mock_frontmatter, mock_notion):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+        mock_frontmatter.read_file.return_value = {
+            "attributes": {"title": "Test Doc"},
+            "body": "Content",
+        }
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs", "-w", "2"])
 
         self.assertEqual(result.exit_code, 0)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 from click.testing import CliRunner
 
-from nogisync.cli import get_content, get_title, main, process_page_hierarchy, sync_file
+from nogisync.cli import get_content, get_title, main, process_page_hierarchy, read_frontmatter, sync_file
 
 
 class TestGetTitle(TestCase):
@@ -29,6 +29,30 @@ class TestGetContent(TestCase):
         mock_open.return_value.__enter__.return_value.read.return_value = "File content"
         self.assertEqual(get_content(Path("test.md"), {}), "File content")
         mock_open.assert_called_once_with(Path("test.md"), "r")
+
+
+class TestReadFrontmatter(TestCase):
+    def test_with_valid_frontmatter(self):
+        with CliRunner().isolated_filesystem():
+            Path("test.md").write_text("---\ntitle: Hello\n---\nBody text")
+            result = read_frontmatter(Path("test.md"))
+        self.assertEqual(result["attributes"]["title"], "Hello")
+        self.assertEqual(result["body"], "Body text")
+
+    def test_without_frontmatter(self):
+        with CliRunner().isolated_filesystem():
+            Path("test.md").write_text("# Just markdown\nNo frontmatter here")
+            result = read_frontmatter(Path("test.md"))
+        self.assertIsNone(result["attributes"])
+        self.assertIn("# Just markdown", result["body"])
+
+    def test_with_invalid_yaml_raises(self):
+        import yaml
+
+        with CliRunner().isolated_filesystem():
+            Path("test.md").write_text("---\n: invalid: yaml: {{{\n---\nBody")
+            with self.assertRaises(yaml.YAMLError):
+                read_frontmatter(Path("test.md"))
 
 
 class TestProcessPageHierarchy(TestCase):
@@ -95,75 +119,49 @@ class TestProcessPageHierarchy(TestCase):
 
 class TestSyncFile(TestCase):
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_creates_new_page(self, mock_frontmatter, mock_notion):
+    def test_creates_new_page(self, mock_notion):
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Test Doc"},
-            "body": "Content",
-        }
 
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
-            sync_file(
-                MagicMock(),
-                Path("docs/test.md"),
-                Path("docs"),
-                "parent-id",
-                True,
-                None,
-                True,
-            )
+            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
 
         mock_notion.create_notion_page.assert_called_once()
 
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_updates_existing_page(self, mock_frontmatter, mock_notion):
+    def test_updates_existing_page(self, mock_notion):
         mock_notion.find_notion_page.return_value = {"id": "existing-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Test Doc"},
-            "body": "Updated content",
-        }
 
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nUpdated content")
-            sync_file(
-                MagicMock(),
-                Path("docs/test.md"),
-                Path("docs"),
-                "parent-id",
-                True,
-                None,
-                True,
-            )
+            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
 
         mock_notion.update_notion_page.assert_called_once()
 
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_handles_yaml_error(self, mock_frontmatter, mock_notion):
-        import yaml
-
+    def test_handles_no_frontmatter(self, mock_notion):
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.side_effect = yaml.YAMLError("bad yaml")
 
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
-            Path("docs/test.md").write_text("# No frontmatter")
-            sync_file(
-                MagicMock(),
-                Path("docs/test.md"),
-                Path("docs"),
-                "parent-id",
-                True,
-                None,
-                True,
-            )
+            Path("docs/test.md").write_text("# No frontmatter\nJust content")
+            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
+
+        mock_notion.create_notion_page.assert_called_once()
+
+    @patch("nogisync.cli.notion")
+    def test_handles_invalid_yaml_frontmatter(self, mock_notion):
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\n: invalid: yaml: {{{\n---\nBody content")
+            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
 
         mock_notion.create_notion_page.assert_called_once()
 
@@ -187,37 +185,27 @@ class TestMainFailure(TestCase):
 
 class TestMain(TestCase):
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_syncs_files_in_parallel(self, mock_frontmatter, mock_notion):
+    def test_syncs_files_in_parallel(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Test Doc"},
-            "body": "Content",
-        }
 
         with runner.isolated_filesystem():
             Path("docs").mkdir()
-            Path("docs/a.md").write_text("---\ntitle: Test Doc\n---\nContent")
-            Path("docs/b.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            Path("docs/a.md").write_text("---\ntitle: Doc A\n---\nContent A")
+            Path("docs/b.md").write_text("---\ntitle: Doc B\n---\nContent B")
             result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
 
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(mock_notion.create_notion_page.call_count, 2)
 
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_with_subdirectories(self, mock_frontmatter, mock_notion):
+    def test_with_subdirectories(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Nested Doc"},
-            "body": "Content",
-        }
 
         with runner.isolated_filesystem():
             Path("docs/subdir").mkdir(parents=True)
@@ -227,16 +215,11 @@ class TestMain(TestCase):
         self.assertEqual(result.exit_code, 0)
 
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_with_provenance_disabled(self, mock_frontmatter, mock_notion):
+    def test_with_provenance_disabled(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Test Doc"},
-            "body": "Content",
-        }
 
         with runner.isolated_filesystem():
             Path("docs").mkdir()
@@ -248,16 +231,11 @@ class TestMain(TestCase):
         self.assertEqual(result.exit_code, 0)
 
     @patch("nogisync.cli.notion")
-    @patch("nogisync.cli.Frontmatter")
-    def test_custom_workers(self, mock_frontmatter, mock_notion):
+    def test_custom_workers(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
         mock_notion.create_notion_page.return_value = {"id": "new-page"}
-        mock_frontmatter.read_file.return_value = {
-            "attributes": {"title": "Test Doc"},
-            "body": "Content",
-        }
 
         with runner.isolated_filesystem():
             Path("docs").mkdir()

--- a/tests/test_markdown.py
+++ b/tests/test_markdown.py
@@ -2,6 +2,7 @@ import textwrap
 from unittest import TestCase
 
 from nogisync.markdown import (
+    NOTION_MAX_LIST_DEPTH,
     convert_markdown_table_to_latex,
     parse_markdown_to_notion_blocks,
     process_inline_formatting,
@@ -74,6 +75,15 @@ class TestParseBlocks(TestCase):
         self.assertEqual(blocks[0]["code"]["language"], "python")
         self.assertIn("print('hello')", blocks[0]["code"]["rich_text"][0]["text"]["content"])
 
+    def test_code_block_unsupported_language_falls_back_to_plain_text(self):
+        blocks = parse_markdown_to_notion_blocks("```text\nhello\n```")
+        self.assertEqual(blocks[0]["code"]["language"], "plain text")
+
+    def test_code_block_supported_language_preserved(self):
+        for lang in ("mermaid", "sql", "typescript", "yaml"):
+            blocks = parse_markdown_to_notion_blocks(f"```{lang}\ncontent\n```")
+            self.assertEqual(blocks[0]["code"]["language"], lang)
+
     def test_indented_code_flushed_by_regular_line(self):
         result = parse_markdown_to_notion_blocks("    code line\nregular line")
         self.assertEqual(result[0]["type"], "code")
@@ -98,6 +108,14 @@ class TestParseBlocks(TestCase):
         result = parse_markdown_to_notion_blocks("![](https://example.com/image.png)")
         self.assertEqual(result[0]["type"], "image")
         self.assertNotIn("caption", result[0]["image"])
+
+    def test_image_relative_url_becomes_paragraph(self):
+        result = parse_markdown_to_notion_blocks("![diagram](./architecture.png)")
+        self.assertEqual(result[0]["type"], "paragraph")
+
+    def test_image_http_url_accepted(self):
+        result = parse_markdown_to_notion_blocks("![](http://example.com/img.png)")
+        self.assertEqual(result[0]["type"], "image")
 
     def test_empty_lines_filtered(self):
         result = parse_markdown_to_notion_blocks("**bold** \n\n *italic*")
@@ -217,6 +235,35 @@ class TestParseLists(TestCase):
             child = result[i]["bulleted_list_item"]["children"][0]
             self.assertEqual(child["type"], "numbered_list_item")
             self.assertEqual(child["numbered_list_item"]["rich_text"][0]["text"]["content"], child_text)
+
+
+class TestListNestingDepthLimit(TestCase):
+    def test_bulleted_list_capped_at_max_depth(self):
+        lines = []
+        for i in range(NOTION_MAX_LIST_DEPTH + 2):
+            lines.append("  " * i + f"- Level {i}")
+        result = parse_markdown_to_notion_blocks("\n".join(lines))
+
+        # Walk down the nesting to verify depth is capped
+        node = result[0]
+        depth = 1
+        while "children" in node.get("bulleted_list_item", {}):
+            node = node["bulleted_list_item"]["children"][0]
+            depth += 1
+        self.assertLessEqual(depth, NOTION_MAX_LIST_DEPTH)
+
+    def test_numbered_list_capped_at_max_depth(self):
+        lines = []
+        for i in range(NOTION_MAX_LIST_DEPTH + 2):
+            lines.append("  " * i + f"{i + 1}. Level {i}")
+        result = parse_markdown_to_notion_blocks("\n".join(lines))
+
+        node = result[0]
+        depth = 1
+        while "children" in node.get("numbered_list_item", {}):
+            node = node["numbered_list_item"]["children"][0]
+            depth += 1
+        self.assertLessEqual(depth, NOTION_MAX_LIST_DEPTH)
 
 
 class TestNestedListFallback(TestCase):

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -3,8 +3,10 @@ from unittest.mock import MagicMock, patch
 
 import httpx
 import notion_client.errors
+import stamina
 
 from nogisync.notion import (
+    _is_rate_limited,
     create_notion_page,
     find_notion_page,
     get_notion_client,
@@ -13,11 +15,13 @@ from nogisync.notion import (
 )
 from nogisync.provenance import ProvenanceConfig
 
+stamina.set_testing(True)
 
-def make_api_error():
+
+def make_api_error(status: int = 400):
     return notion_client.errors.APIResponseError(
-        code="error",
-        status=400,
+        code="rate_limited" if status == 429 else "error",
+        status=status,
         message="error",
         headers=httpx.Headers(),
         raw_body_text="",
@@ -167,3 +171,28 @@ class TestUpdateNotionPage(TestCase):
     def test_handles_api_error(self):
         self.mock_client.blocks.children.list.side_effect = make_api_error()
         update_notion_page(self.mock_client, "page-id", "content")
+
+
+class TestIsRateLimited(TestCase):
+    def test_returns_true_for_429(self):
+        self.assertTrue(_is_rate_limited(make_api_error(status=429)))
+
+    def test_returns_false_for_other_status(self):
+        self.assertFalse(_is_rate_limited(make_api_error(status=400)))
+
+    def test_returns_false_for_non_api_error(self):
+        self.assertFalse(_is_rate_limited(ValueError("not an API error")))
+
+
+class TestRateLimitRetry(TestCase):
+    def test_create_reraises_429(self):
+        mock_client = MagicMock()
+        mock_client.pages.create.side_effect = make_api_error(status=429)
+        with self.assertRaises(notion_client.errors.APIResponseError):
+            create_notion_page(mock_client, "parent-id", "Title", "content")
+
+    def test_update_reraises_429(self):
+        mock_client = MagicMock()
+        mock_client.blocks.children.list.side_effect = make_api_error(status=429)
+        with self.assertRaises(notion_client.errors.APIResponseError):
+            update_notion_page(mock_client, "page-id", "content")

--- a/uv.lock
+++ b/uv.lock
@@ -361,10 +361,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click" },
-    { name = "frontmatter" },
-    { name = "notion-client" },
-    { name = "stamina", specifier = ">=25.2.0" },
+    { name = "click", specifier = ">=8,<9" },
+    { name = "frontmatter", specifier = ">=3,<4" },
+    { name = "notion-client", specifier = ">=3,<4" },
+    { name = "stamina", specifier = ">=25.2,<26" },
 ]
 
 [package.metadata.requires-dev]

--- a/uv.lock
+++ b/uv.lock
@@ -138,15 +138,6 @@ wheels = [
 ]
 
 [[package]]
-name = "frontmatter"
-version = "3.0.8"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyyaml" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/de/7425e1c97db39ca6615ccf89d8c3b47f2ee8dfdabb754fc99f925ee1a702/frontmatter-3.0.8.tar.gz", hash = "sha256:d913619d20f607e03557d52a8bf9b249e0b3093c770c5213c0f1231d2c97fe73", size = 5254, upload-time = "2024-03-08T07:55:51.023Z" }
-
-[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -341,8 +332,8 @@ version = "1.0.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
-    { name = "frontmatter" },
     { name = "notion-client" },
+    { name = "pyyaml" },
     { name = "stamina" },
 ]
 
@@ -362,8 +353,8 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8,<9" },
-    { name = "frontmatter", specifier = ">=3,<4" },
     { name = "notion-client", specifier = ">=3,<4" },
+    { name = "pyyaml", specifier = ">=5.4,<7" },
     { name = "stamina", specifier = ">=25.2,<26" },
 ]
 
@@ -563,9 +554,29 @@ wheels = [
 
 [[package]]
 name = "pyyaml"
-version = "5.1"
+version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9f/2c/9417b5c774792634834e730932745bc09a7d36754ca00acf1ccd1ac2594d/PyYAML-5.1.tar.gz", hash = "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95", size = 274244, upload-time = "2019-03-13T16:35:50.361Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
 
 [[package]]
 name = "ruff"

--- a/uv.lock
+++ b/uv.lock
@@ -343,6 +343,7 @@ dependencies = [
     { name = "click" },
     { name = "frontmatter" },
     { name = "notion-client" },
+    { name = "stamina" },
 ]
 
 [package.dev-dependencies]
@@ -363,6 +364,7 @@ requires-dist = [
     { name = "click" },
     { name = "frontmatter" },
     { name = "notion-client" },
+    { name = "stamina", specifier = ">=25.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -611,6 +613,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
+name = "stamina"
+version = "25.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/b7/8064b246b3d684720080ee8ffbf1dde5caabe852eb9cb53655eb97992af2/stamina-25.2.0.tar.gz", hash = "sha256:fdff938789e8a0c4c496e1ee8a08ee3c7c3351239f235b53e60d4f5964d07e19", size = 565737, upload-time = "2025-12-11T09:16:59.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/81/c525760353dff91ae2e4c42c3f3d9bf0bfeecbb6165cc393e86915f1717d/stamina-25.2.0-py3-none-any.whl", hash = "sha256:7f0de7dba735464c256a31e6372c01b8bb51fb6efd649e6773f4ce804462feea", size = 18791, upload-time = "2025-12-11T09:16:57.235Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Syncs files in parallel using `ThreadPoolExecutor` (default 4 workers, configurable via `--workers/-w`)
- Adds `stamina` retry with exponential backoff (1s initial, 30s max, 5 attempts) for Notion API 429 rate limits
- Creates Notion client once instead of per-file
- Caches directory hierarchy lookups to avoid redundant API calls
- Pre-resolves all directory hierarchies sequentially, then passes resolved parent IDs to parallel workers — no shared mutable state across threads
- Replaces `print()` with structured logging including per-file start/finish timing
- Adds summary log with total elapsed time and failure count
- Caps list nesting at 3 levels (Notion rejects deeper nesting)
- Validates code block languages against Notion's supported set, falling back to `plain text` for unsupported values
- Skips image blocks with relative/non-HTTP URLs, rendering them as text paragraphs instead