### PR TITLE
feat: Add markdown-based sync method

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ jobs:
 | `notion_api_key` | Notion API key for authentication | Yes | - |
 | `notion_parent_page_id` | ID of the parent page in Notion | Yes | - |
 | `docs_path` | Path to directory containing markdown files | No | `.` |
+| `sync_method` | Sync method: `blocks` (convert to Notion blocks) or `markdown` (use Notion markdown API) | No | `blocks` |
 
 ## Example Directory Structure
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ jobs:
 | `notion_parent_page_id` | ID of the parent page in Notion | Yes | - |
 | `docs_path` | Path to directory containing markdown files | No | `.` |
 | `sync_method` | Sync method: `blocks` (convert to Notion blocks) or `markdown` (use Notion markdown API) | No | `blocks` |
+| `fail_on_error` | Fail the action if any page fails to sync | No | `false` |
 
 ## Example Directory Structure
 

--- a/action.yaml
+++ b/action.yaml
@@ -19,6 +19,10 @@ inputs:
     description: "Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)"
     required: false
     default: 'blocks'
+  fail_on_error:
+    description: 'Fail the action if any page fails to sync'
+    required: false
+    default: 'false'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -32,3 +36,4 @@ runs:
     - ${{ inputs.notion_parent_page_id }}
     - "--sync-method"
     - ${{ inputs.sync_method }}
+    - ${{ inputs.fail_on_error == 'true' && '--fail-on-error' || '--no-fail-on-error' }}

--- a/action.yaml
+++ b/action.yaml
@@ -15,6 +15,10 @@ inputs:
   notion_parent_page_id:
     description: 'Notion parent page id'
     required: true
+  sync_method:
+    description: "Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)"
+    required: false
+    default: 'blocks'
 runs:
   using: 'docker'
   image: 'Dockerfile'
@@ -26,3 +30,5 @@ runs:
     - ${{ inputs.docs_path }}
     - "--parent-page-id"
     - ${{ inputs.notion_parent_page_id }}
+    - "--sync-method"
+    - ${{ inputs.sync_method }}

--- a/src/nogisync/cli.py
+++ b/src/nogisync/cli.py
@@ -61,6 +61,8 @@ def sync_file(
     provenance: bool,
     provenance_source_url: str | None,
     provenance_timestamp: bool,
+    sync_method: str = "blocks",
+    markdown_client=None,
 ) -> None:
     """Sync a single markdown file to Notion."""
     relative_path = md_file.relative_to(path)
@@ -87,10 +89,18 @@ def sync_file(
 
     if existing_page:
         logger.info("Updating existing page: %s", title)
-        notion.update_notion_page(client, existing_page["id"], content, provenance_config)
+        if sync_method == "markdown":
+            notion.update_notion_page_markdown(markdown_client, existing_page["id"], content, provenance_config)
+        else:
+            notion.update_notion_page(client, existing_page["id"], content, provenance_config)
     else:
         logger.info("Creating new page: %s", title)
-        notion.create_notion_page(client, parent_page_id, title, content, provenance_config)
+        if sync_method == "markdown":
+            notion.create_notion_page_markdown(
+                client, markdown_client, parent_page_id, title, content, provenance_config
+            )
+        else:
+            notion.create_notion_page(client, parent_page_id, title, content, provenance_config)
 
     elapsed = time.monotonic() - start
     logger.info("Finished syncing %s (%.1fs)", relative_path, elapsed)
@@ -122,6 +132,12 @@ def sync_file(
     help="Include sync timestamp in provenance (default: enabled)",
 )
 @click.option(
+    "--sync-method",
+    type=click.Choice(["blocks", "markdown"], case_sensitive=False),
+    default="blocks",
+    help="Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)",
+)
+@click.option(
     "--workers",
     "-w",
     type=int,
@@ -135,6 +151,7 @@ def main(
     provenance: bool,
     provenance_source_url: str | None,
     provenance_timestamp: bool,
+    sync_method: str,
     workers: int,
 ) -> None:
     """
@@ -147,6 +164,7 @@ def main(
     start = time.monotonic()
 
     client = notion.get_notion_client(token)
+    markdown_client = notion.get_notion_markdown_client(token) if sync_method == "markdown" else None
 
     # Pre-resolve directory hierarchies sequentially (they depend on parent IDs)
     hierarchy_cache: dict[str, str] = {}
@@ -174,6 +192,8 @@ def main(
                 provenance,
                 provenance_source_url,
                 provenance_timestamp,
+                sync_method,
+                markdown_client,
             ): md_file
             for md_file in markdown_files
         }

--- a/src/nogisync/cli.py
+++ b/src/nogisync/cli.py
@@ -138,6 +138,11 @@ def sync_file(
     help="Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)",
 )
 @click.option(
+    "--fail-on-error/--no-fail-on-error",
+    default=False,
+    help="Exit with non-zero status if any page fails to sync (default: disabled)",
+)
+@click.option(
     "--workers",
     "-w",
     type=int,
@@ -152,6 +157,7 @@ def main(
     provenance_source_url: str | None,
     provenance_timestamp: bool,
     sync_method: str,
+    fail_on_error: bool,
     workers: int,
 ) -> None:
     """
@@ -207,6 +213,9 @@ def main(
 
     elapsed = time.monotonic() - start
     logger.info("Sync complete: %d files in %.1fs (%d failed)", len(markdown_files), elapsed, len(failed))
+
+    if failed and fail_on_error:
+        raise SystemExit(1)
 
 
 _FRONTMATTER_RE = re.compile(r"^\s*(?:---|\+\+\+)(.*?)(?:---|\+\+\+)\s*(.+)$", re.DOTALL)

--- a/src/nogisync/notion.py
+++ b/src/nogisync/notion.py
@@ -133,9 +133,7 @@ def _prepare_markdown_content(content: str, provenance_config: ProvenanceConfig 
     if not provenance_config or not provenance_config.enabled or not content:
         return content
     provenance_text = create_provenance_markdown(provenance_config)
-    if provenance_text:
-        return provenance_text + "\n\n" + content
-    return content
+    return provenance_text + "\n\n" + content if provenance_text else content
 
 
 @stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)

--- a/src/nogisync/notion.py
+++ b/src/nogisync/notion.py
@@ -163,7 +163,10 @@ def create_notion_page_markdown(
         markdown_client.request(
             path=f"/pages/{new_page['id']}/markdown",
             method="PATCH",
-            body={"replace_content": markdown_content},
+            body={
+                "type": "replace_content",
+                "replace_content": {"new_str": markdown_content, "allow_deleting_content": True},
+            },
         )
 
         return cast(dict, new_page)
@@ -188,7 +191,10 @@ def update_notion_page_markdown(
         markdown_client.request(
             path=f"/pages/{page_id}/markdown",
             method="PATCH",
-            body={"replace_content": markdown_content},
+            body={
+                "type": "replace_content",
+                "replace_content": {"new_str": markdown_content, "allow_deleting_content": True},
+            },
         )
     except notion_client.errors.APIResponseError as e:
         if e.status == 429:

--- a/src/nogisync/notion.py
+++ b/src/nogisync/notion.py
@@ -5,7 +5,7 @@ import notion_client
 import stamina
 
 from nogisync.markdown import parse_md
-from nogisync.provenance import ProvenanceConfig, create_provenance_block
+from nogisync.provenance import ProvenanceConfig, create_provenance_block, create_provenance_markdown
 
 logger = logging.getLogger(__name__)
 
@@ -15,9 +15,17 @@ def _is_rate_limited(error: Exception) -> bool:
     return isinstance(error, notion_client.errors.APIResponseError) and error.status == 429
 
 
+MARKDOWN_API_VERSION = "2026-03-11"
+
+
 def get_notion_client(token: str) -> notion_client.Client:
     """Get a Notion client."""
     return notion_client.Client(auth=token)
+
+
+def get_notion_markdown_client(token: str) -> notion_client.Client:
+    """Get a Notion client configured for the markdown API endpoints."""
+    return notion_client.Client(auth=token, notion_version=MARKDOWN_API_VERSION)
 
 
 def get_notion_parent_page(client: notion_client.Client, parent_page_id: str) -> dict | None:
@@ -114,6 +122,74 @@ def update_notion_page(
             blocks = blocks[100:]
 
         client.blocks.children.append(block_id=page_id, children=blocks)
+    except notion_client.errors.APIResponseError as e:
+        if e.status == 429:
+            raise
+        logger.error(e)
+
+
+def _prepare_markdown_content(content: str, provenance_config: ProvenanceConfig | None = None) -> str:
+    """Prepend provenance as markdown text to the content string."""
+    if not provenance_config or not provenance_config.enabled or not content:
+        return content
+    provenance_text = create_provenance_markdown(provenance_config)
+    if provenance_text:
+        return provenance_text + "\n\n" + content
+    return content
+
+
+@stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)
+def create_notion_page_markdown(
+    client: notion_client.Client,
+    markdown_client: notion_client.Client,
+    parent_page_id: str,
+    title: str,
+    content: str,
+    provenance_config: ProvenanceConfig | None = None,
+) -> dict:
+    """Create a new page in Notion using the markdown API."""
+    try:
+        markdown_content = _prepare_markdown_content(content, provenance_config)
+
+        new_page = cast(
+            dict,
+            client.pages.create(
+                parent={"page_id": parent_page_id},
+                properties={"title": [{"text": {"content": title}}]},
+                children=[],
+            ),
+        )
+
+        markdown_client.request(
+            path=f"/pages/{new_page['id']}/markdown",
+            method="PATCH",
+            body={"replace_content": markdown_content},
+        )
+
+        return cast(dict, new_page)
+    except notion_client.errors.APIResponseError as e:
+        if e.status == 429:
+            raise
+        logger.error(e)
+        return {}
+
+
+@stamina.retry(on=_is_rate_limited, attempts=5, wait_initial=1.0, wait_max=30.0)
+def update_notion_page_markdown(
+    markdown_client: notion_client.Client,
+    page_id: str,
+    content: str,
+    provenance_config: ProvenanceConfig | None = None,
+) -> None:
+    """Update an existing Notion page using the markdown API."""
+    try:
+        markdown_content = _prepare_markdown_content(content, provenance_config)
+
+        markdown_client.request(
+            path=f"/pages/{page_id}/markdown",
+            method="PATCH",
+            body={"replace_content": markdown_content},
+        )
     except notion_client.errors.APIResponseError as e:
         if e.status == 429:
             raise

--- a/src/nogisync/provenance.py
+++ b/src/nogisync/provenance.py
@@ -91,3 +91,43 @@ def create_provenance_block(config: ProvenanceConfig) -> dict | None:
             "color": "yellow_background",
         },
     }
+
+
+def _build_provenance_message_parts(config: ProvenanceConfig) -> list[str] | None:
+    """Build provenance message parts shared by both block and markdown formats.
+
+    Returns None if provenance is disabled.
+    """
+    if not config.enabled:
+        return None
+
+    message_parts = ["This page is synced from GitHub. Edits will be overwritten."]
+
+    if config.file_path:
+        if config.source_url:
+            full_url = f"{config.source_url.rstrip('/')}/{config.file_path}"
+            if len(full_url) > 1900:
+                full_url = full_url[:1897] + "..."
+            message_parts.append(f"Source: {full_url}")
+        else:
+            source_path = config.file_path
+            if len(source_path) > 1900:
+                source_path = source_path[:1897] + "..."
+            message_parts.append(f"Source: {source_path}")
+
+    if config.include_timestamp:
+        timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        message_parts.append(f"Last synced: {timestamp}")
+
+    return message_parts
+
+
+def create_provenance_markdown(config: ProvenanceConfig) -> str | None:
+    """Create a markdown blockquote with provenance information.
+
+    Returns None if provenance is disabled.
+    """
+    parts = _build_provenance_message_parts(config)
+    if parts is None:
+        return None
+    return "\n".join(f"> {part}" for part in parts)

--- a/src/nogisync/provenance.py
+++ b/src/nogisync/provenance.py
@@ -123,11 +123,12 @@ def _build_provenance_message_parts(config: ProvenanceConfig) -> list[str] | Non
 
 
 def create_provenance_markdown(config: ProvenanceConfig) -> str | None:
-    """Create a markdown blockquote with provenance information.
+    """Create an enhanced markdown callout with provenance information.
 
     Returns None if provenance is disabled.
     """
     parts = _build_provenance_message_parts(config)
     if parts is None:
         return None
-    return "\n".join(f"> {part}" for part in parts)
+    content = "\n".join(f"\t{part}" for part in parts)
+    return f'<callout icon="⚠️" color="yellow_background">\n{content}\n</callout>'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -165,6 +165,53 @@ class TestSyncFile(TestCase):
 
         mock_notion.create_notion_page.assert_called_once()
 
+    @patch("nogisync.cli.notion")
+    def test_creates_new_page_markdown_method(self, mock_notion):
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page_markdown.return_value = {"id": "new-page"}
+        mock_markdown_client = MagicMock()
+
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            sync_file(
+                MagicMock(),
+                Path("docs/test.md"),
+                Path("docs"),
+                "parent-id",
+                True,
+                None,
+                True,
+                sync_method="markdown",
+                markdown_client=mock_markdown_client,
+            )
+
+        mock_notion.create_notion_page_markdown.assert_called_once()
+        mock_notion.create_notion_page.assert_not_called()
+
+    @patch("nogisync.cli.notion")
+    def test_updates_existing_page_markdown_method(self, mock_notion):
+        mock_notion.find_notion_page.return_value = {"id": "existing-page"}
+        mock_markdown_client = MagicMock()
+
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nUpdated content")
+            sync_file(
+                MagicMock(),
+                Path("docs/test.md"),
+                Path("docs"),
+                "parent-id",
+                True,
+                None,
+                True,
+                sync_method="markdown",
+                markdown_client=mock_markdown_client,
+            )
+
+        mock_notion.update_notion_page_markdown.assert_called_once()
+        mock_notion.update_notion_page.assert_not_called()
+
 
 class TestMainFailure(TestCase):
     @patch("nogisync.cli.sync_file", side_effect=RuntimeError("API down"))
@@ -229,6 +276,42 @@ class TestMain(TestCase):
             )
 
         self.assertEqual(result.exit_code, 0)
+
+    @patch("nogisync.cli.notion")
+    def test_with_markdown_sync_method(self, mock_notion):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.get_notion_markdown_client.return_value = MagicMock()
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page_markdown.return_value = {"id": "new-page"}
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            result = runner.invoke(
+                main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs", "--sync-method", "markdown"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+        mock_notion.get_notion_markdown_client.assert_called_once_with("fake-token")
+        mock_notion.create_notion_page_markdown.assert_called_once()
+        mock_notion.create_notion_page.assert_not_called()
+
+    @patch("nogisync.cli.notion")
+    def test_default_sync_method_is_blocks(self, mock_notion):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
+            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
+
+        self.assertEqual(result.exit_code, 0)
+        mock_notion.create_notion_page.assert_called_once()
+        mock_notion.create_notion_page_markdown.assert_not_called()
 
     @patch("nogisync.cli.notion")
     def test_custom_workers(self, mock_notion):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -229,6 +229,38 @@ class TestMainFailure(TestCase):
         self.assertEqual(result.exit_code, 0)
         mock_sync.assert_called_once()
 
+    @patch("nogisync.cli.sync_file", side_effect=RuntimeError("API down"))
+    @patch("nogisync.cli.process_page_hierarchy")
+    @patch("nogisync.cli.notion")
+    def test_fail_on_error_exits_nonzero(self, mock_notion, mock_hierarchy, mock_sync):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("content")
+            result = runner.invoke(
+                main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs", "--fail-on-error"]
+            )
+
+        self.assertEqual(result.exit_code, 1)
+
+    @patch("nogisync.cli.sync_file", side_effect=RuntimeError("API down"))
+    @patch("nogisync.cli.process_page_hierarchy")
+    @patch("nogisync.cli.notion")
+    def test_no_fail_on_error_exits_zero(self, mock_notion, mock_hierarchy, mock_sync):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("docs/test.md").write_text("content")
+            result = runner.invoke(
+                main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs", "--no-fail-on-error"]
+            )
+
+        self.assertEqual(result.exit_code, 0)
+
 
 class TestMain(TestCase):
     @patch("nogisync.cli.notion")

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -264,7 +264,10 @@ class TestCreateNotionPageMarkdown(TestCase):
         self.mock_markdown_client.request.assert_called_once_with(
             path="/pages/new-page-id/markdown",
             method="PATCH",
-            body={"replace_content": "Content"},
+            body={
+                "type": "replace_content",
+                "replace_content": {"new_str": "Content", "allow_deleting_content": True},
+            },
         )
 
     def test_with_provenance(self):
@@ -273,8 +276,8 @@ class TestCreateNotionPageMarkdown(TestCase):
             self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content", provenance_config=config
         )
         body = self.mock_markdown_client.request.call_args[1]["body"]
-        self.assertIn("> This page is synced from GitHub", body["replace_content"])
-        self.assertTrue(body["replace_content"].endswith("\n\nContent"))
+        self.assertIn("> This page is synced from GitHub", body["replace_content"]["new_str"])
+        self.assertTrue(body["replace_content"]["new_str"].endswith("\n\nContent"))
 
     def test_with_provenance_disabled(self):
         config = ProvenanceConfig(enabled=False, file_path="docs/test.md")
@@ -282,7 +285,7 @@ class TestCreateNotionPageMarkdown(TestCase):
             self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content", provenance_config=config
         )
         body = self.mock_markdown_client.request.call_args[1]["body"]
-        self.assertEqual(body["replace_content"], "Content")
+        self.assertEqual(body["replace_content"]["new_str"], "Content")
 
     def test_returns_empty_dict_on_api_error(self):
         self.mock_client.pages.create.side_effect = make_api_error()
@@ -305,14 +308,17 @@ class TestUpdateNotionPageMarkdown(TestCase):
         self.mock_markdown_client.request.assert_called_once_with(
             path="/pages/page-id/markdown",
             method="PATCH",
-            body={"replace_content": "Updated content"},
+            body={
+                "type": "replace_content",
+                "replace_content": {"new_str": "Updated content", "allow_deleting_content": True},
+            },
         )
 
     def test_with_provenance(self):
         config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="docs/test.md")
         update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content", provenance_config=config)
         body = self.mock_markdown_client.request.call_args[1]["body"]
-        self.assertIn("> This page is synced from GitHub", body["replace_content"])
+        self.assertIn("> This page is synced from GitHub", body["replace_content"]["new_str"])
 
     def test_no_block_deletion(self):
         update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content")

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -6,12 +6,17 @@ import notion_client.errors
 import stamina
 
 from nogisync.notion import (
+    MARKDOWN_API_VERSION,
     _is_rate_limited,
+    _prepare_markdown_content,
     create_notion_page,
+    create_notion_page_markdown,
     find_notion_page,
     get_notion_client,
+    get_notion_markdown_client,
     get_notion_parent_page,
     update_notion_page,
+    update_notion_page_markdown,
 )
 from nogisync.provenance import ProvenanceConfig
 
@@ -196,3 +201,125 @@ class TestRateLimitRetry(TestCase):
         mock_client.blocks.children.list.side_effect = make_api_error(status=429)
         with self.assertRaises(notion_client.errors.APIResponseError):
             update_notion_page(mock_client, "page-id", "content")
+
+    def test_create_markdown_reraises_429(self):
+        mock_client = MagicMock()
+        mock_markdown_client = MagicMock()
+        mock_client.pages.create.side_effect = make_api_error(status=429)
+        with self.assertRaises(notion_client.errors.APIResponseError):
+            create_notion_page_markdown(mock_client, mock_markdown_client, "parent-id", "Title", "content")
+
+    def test_update_markdown_reraises_429(self):
+        mock_markdown_client = MagicMock()
+        mock_markdown_client.request.side_effect = make_api_error(status=429)
+        with self.assertRaises(notion_client.errors.APIResponseError):
+            update_notion_page_markdown(mock_markdown_client, "page-id", "content")
+
+
+class TestGetNotionMarkdownClient(TestCase):
+    @patch("notion_client.Client")
+    def test_returns_client_with_markdown_version(self, mock_client):
+        client = get_notion_markdown_client("test-token")
+        mock_client.assert_called_once_with(auth="test-token", notion_version=MARKDOWN_API_VERSION)
+        self.assertIsNotNone(client)
+
+
+class TestPrepareMarkdownContent(TestCase):
+    def test_returns_content_without_provenance(self):
+        self.assertEqual(_prepare_markdown_content("Hello"), "Hello")
+
+    def test_returns_content_when_provenance_disabled(self):
+        config = ProvenanceConfig(enabled=False)
+        self.assertEqual(_prepare_markdown_content("Hello", config), "Hello")
+
+    def test_returns_empty_content_unchanged(self):
+        config = ProvenanceConfig(enabled=True, file_path="test.md")
+        self.assertEqual(_prepare_markdown_content("", config), "")
+
+    def test_prepends_provenance(self):
+        config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="test.md")
+        result = _prepare_markdown_content("Hello", config)
+        self.assertTrue(result.startswith("> "))
+        self.assertTrue(result.endswith("\n\nHello"))
+
+
+class TestCreateNotionPageMarkdown(TestCase):
+    def setUp(self):
+        self.mock_client = MagicMock()
+        self.mock_markdown_client = MagicMock()
+        self.mock_client.pages.create.return_value = {"id": "new-page-id"}
+
+    def test_creates_page_and_sets_markdown(self):
+        result = create_notion_page_markdown(
+            self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content"
+        )
+        self.assertEqual(result, {"id": "new-page-id"})
+
+        # Page shell created via standard client
+        call_args = self.mock_client.pages.create.call_args[1]
+        self.assertEqual(call_args["parent"]["page_id"], "parent-id")
+        self.assertEqual(call_args["properties"]["title"][0]["text"]["content"], "Title")
+
+        # Content set via markdown client
+        self.mock_markdown_client.request.assert_called_once_with(
+            path="/pages/new-page-id/markdown",
+            method="PATCH",
+            body={"replace_content": "Content"},
+        )
+
+    def test_with_provenance(self):
+        config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="docs/test.md")
+        create_notion_page_markdown(
+            self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content", provenance_config=config
+        )
+        body = self.mock_markdown_client.request.call_args[1]["body"]
+        self.assertIn("> This page is synced from GitHub", body["replace_content"])
+        self.assertTrue(body["replace_content"].endswith("\n\nContent"))
+
+    def test_with_provenance_disabled(self):
+        config = ProvenanceConfig(enabled=False, file_path="docs/test.md")
+        create_notion_page_markdown(
+            self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content", provenance_config=config
+        )
+        body = self.mock_markdown_client.request.call_args[1]["body"]
+        self.assertEqual(body["replace_content"], "Content")
+
+    def test_returns_empty_dict_on_api_error(self):
+        self.mock_client.pages.create.side_effect = make_api_error()
+        result = create_notion_page_markdown(
+            self.mock_client, self.mock_markdown_client, "parent-id", "Title", "content"
+        )
+        self.assertEqual(result, {})
+
+    def test_no_blocks_api_calls(self):
+        create_notion_page_markdown(self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content")
+        self.mock_client.blocks.children.append.assert_not_called()
+
+
+class TestUpdateNotionPageMarkdown(TestCase):
+    def setUp(self):
+        self.mock_markdown_client = MagicMock()
+
+    def test_updates_page_via_markdown(self):
+        update_notion_page_markdown(self.mock_markdown_client, "page-id", "Updated content")
+        self.mock_markdown_client.request.assert_called_once_with(
+            path="/pages/page-id/markdown",
+            method="PATCH",
+            body={"replace_content": "Updated content"},
+        )
+
+    def test_with_provenance(self):
+        config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="docs/test.md")
+        update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content", provenance_config=config)
+        body = self.mock_markdown_client.request.call_args[1]["body"]
+        self.assertIn("> This page is synced from GitHub", body["replace_content"])
+
+    def test_no_block_deletion(self):
+        update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content")
+        # The markdown client should not have blocks operations
+        # Just verify request was called once (the markdown PATCH)
+        self.assertEqual(self.mock_markdown_client.request.call_count, 1)
+
+    def test_handles_api_error(self):
+        self.mock_markdown_client.request.side_effect = make_api_error()
+        update_notion_page_markdown(self.mock_markdown_client, "page-id", "content")

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -239,7 +239,7 @@ class TestPrepareMarkdownContent(TestCase):
     def test_prepends_provenance(self):
         config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="test.md")
         result = _prepare_markdown_content("Hello", config)
-        self.assertTrue(result.startswith("> "))
+        self.assertTrue(result.startswith("<callout"))
         self.assertTrue(result.endswith("\n\nHello"))
 
 
@@ -276,7 +276,7 @@ class TestCreateNotionPageMarkdown(TestCase):
             self.mock_client, self.mock_markdown_client, "parent-id", "Title", "Content", provenance_config=config
         )
         body = self.mock_markdown_client.request.call_args[1]["body"]
-        self.assertIn("> This page is synced from GitHub", body["replace_content"]["new_str"])
+        self.assertIn("\tThis page is synced from GitHub", body["replace_content"]["new_str"])
         self.assertTrue(body["replace_content"]["new_str"].endswith("\n\nContent"))
 
     def test_with_provenance_disabled(self):
@@ -318,7 +318,7 @@ class TestUpdateNotionPageMarkdown(TestCase):
         config = ProvenanceConfig(enabled=True, include_timestamp=False, file_path="docs/test.md")
         update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content", provenance_config=config)
         body = self.mock_markdown_client.request.call_args[1]["body"]
-        self.assertIn("> This page is synced from GitHub", body["replace_content"]["new_str"])
+        self.assertIn("\tThis page is synced from GitHub", body["replace_content"]["new_str"])
 
     def test_no_block_deletion(self):
         update_notion_page_markdown(self.mock_markdown_client, "page-id", "Content")

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -2,7 +2,7 @@ import os
 from unittest import TestCase
 from unittest.mock import patch
 
-from nogisync.provenance import ProvenanceConfig, create_provenance_block
+from nogisync.provenance import ProvenanceConfig, create_provenance_block, create_provenance_markdown
 
 
 class TestProvenanceConfig(TestCase):
@@ -160,3 +160,68 @@ class TestCreateProvenanceBlock(TestCase):
         # Should not have double slash
         self.assertIn("main/docs/readme.md", content)
         self.assertNotIn("main//docs", content)
+
+
+class TestCreateProvenanceMarkdown(TestCase):
+    def test_disabled_returns_none(self):
+        config = ProvenanceConfig(enabled=False, file_path="test.md")
+        result = create_provenance_markdown(config)
+        self.assertIsNone(result)
+
+    def test_basic_provenance_markdown(self):
+        config = ProvenanceConfig(
+            enabled=True,
+            include_timestamp=False,
+            file_path="docs/readme.md",
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIsNotNone(result)
+        lines = result.split("\n")
+        self.assertTrue(all(line.startswith("> ") for line in lines))
+        self.assertIn("> This page is synced from GitHub. Edits will be overwritten.", result)
+        self.assertIn("> Source: docs/readme.md", result)
+
+    def test_provenance_markdown_with_source_url(self):
+        config = ProvenanceConfig(
+            enabled=True,
+            source_url="https://github.com/org/repo/blob/main",
+            include_timestamp=False,
+            file_path="docs/readme.md",
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIn("> Source: https://github.com/org/repo/blob/main/docs/readme.md", result)
+
+    def test_provenance_markdown_with_timestamp(self):
+        config = ProvenanceConfig(
+            enabled=True,
+            include_timestamp=True,
+            file_path="docs/readme.md",
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIn("> Last synced:", result)
+        self.assertIn("UTC", result)
+
+    def test_provenance_markdown_without_file_path(self):
+        config = ProvenanceConfig(
+            enabled=True,
+            include_timestamp=False,
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIn("> This page is synced from GitHub", result)
+        self.assertNotIn("Source:", result)
+
+    def test_long_url_truncation(self):
+        long_path = "a" * 2000
+        config = ProvenanceConfig(
+            enabled=True,
+            source_url="https://github.com/org/repo/blob/main",
+            include_timestamp=False,
+            file_path=long_path,
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIn("...", result)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -177,10 +177,10 @@ class TestCreateProvenanceMarkdown(TestCase):
         result = create_provenance_markdown(config)
 
         self.assertIsNotNone(result)
-        lines = result.split("\n")
-        self.assertTrue(all(line.startswith("> ") for line in lines))
-        self.assertIn("> This page is synced from GitHub. Edits will be overwritten.", result)
-        self.assertIn("> Source: docs/readme.md", result)
+        self.assertTrue(result.startswith('<callout icon="⚠️" color="yellow_background">'))
+        self.assertTrue(result.endswith("</callout>"))
+        self.assertIn("\tThis page is synced from GitHub. Edits will be overwritten.", result)
+        self.assertIn("\tSource: docs/readme.md", result)
 
     def test_provenance_markdown_with_source_url(self):
         config = ProvenanceConfig(
@@ -191,7 +191,7 @@ class TestCreateProvenanceMarkdown(TestCase):
         )
         result = create_provenance_markdown(config)
 
-        self.assertIn("> Source: https://github.com/org/repo/blob/main/docs/readme.md", result)
+        self.assertIn("\tSource: https://github.com/org/repo/blob/main/docs/readme.md", result)
 
     def test_provenance_markdown_with_timestamp(self):
         config = ProvenanceConfig(
@@ -201,7 +201,7 @@ class TestCreateProvenanceMarkdown(TestCase):
         )
         result = create_provenance_markdown(config)
 
-        self.assertIn("> Last synced:", result)
+        self.assertIn("\tLast synced:", result)
         self.assertIn("UTC", result)
 
     def test_provenance_markdown_without_file_path(self):
@@ -211,7 +211,7 @@ class TestCreateProvenanceMarkdown(TestCase):
         )
         result = create_provenance_markdown(config)
 
-        self.assertIn("> This page is synced from GitHub", result)
+        self.assertIn("\tThis page is synced from GitHub", result)
         self.assertNotIn("Source:", result)
 
     def test_long_url_truncation(self):
@@ -219,6 +219,17 @@ class TestCreateProvenanceMarkdown(TestCase):
         config = ProvenanceConfig(
             enabled=True,
             source_url="https://github.com/org/repo/blob/main",
+            include_timestamp=False,
+            file_path=long_path,
+        )
+        result = create_provenance_markdown(config)
+
+        self.assertIn("...", result)
+
+    def test_long_file_path_truncation(self):
+        long_path = "a" * 2000
+        config = ProvenanceConfig(
+            enabled=True,
             include_timestamp=False,
             file_path=long_path,
         )


### PR DESCRIPTION
## Summary
- Adds `--sync-method` CLI option (`blocks` | `markdown`, default: `blocks`) to use Notion's new markdown API endpoints (`PATCH /v1/pages/{page_id}/markdown`) instead of converting markdown to Notion blocks
- The markdown method sends raw markdown directly via `replace_content`, bypassing the block conversion pipeline entirely
- Provenance uses Notion's enhanced markdown `<callout>` syntax with warning icon and yellow background, matching the block-mode styling
- Adds `--fail-on-error/--no-fail-on-error` flag (default: disabled) to exit with non-zero status when any page fails to sync
- Both `sync_method` and `fail_on_error` are exposed as GitHub Action inputs