### PR TITLE
Support multiple directories and default to markdown sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-# Notion-GitHub Page Sync Action
+# nogisync
 
-This GitHub Action synchronizes markdown files from your repository with Notion pages, maintaining the directory structure as the page hierarchy in Notion. It provides a seamless way to keep your documentation in sync between GitHub and Notion.
+Sync markdown files from a GitHub repository to Notion pages. Directory structure is preserved as a page hierarchy in Notion. Pages are created or updated based on frontmatter titles.
 
 ## Features
 
-- 🔄 Bi-directional synchronization between GitHub markdown files and Notion pages
 - 📁 Preserves directory structure as Notion page hierarchy
-- 🔍 Supports multiple directory monitoring
-- 🎯 Selective synchronization based on file patterns
-- 📝 Maintains markdown formatting compatibility
-- 🔒 Secure handling of Notion API credentials
+- 📂 Supports multiple directories via YAML list, newline, or comma separation
+- 📝 Extracts page titles from YAML frontmatter
+- 🔗 Adds provenance callouts linking back to the source file on GitHub
+- ⚡ Parallel syncing with configurable worker count
+- 🔀 Two sync methods: `markdown` (Notion markdown API) or `blocks` (convert to Notion blocks)
 
 ## Prerequisites
 
@@ -28,27 +28,52 @@ This GitHub Action synchronizes markdown files from your repository with Notion 
 
 ## Usage
 
+### GitHub Action
+
 Add the following workflow to your repository (e.g., `.github/workflows/notion-sync.yml`):
 
 ```yaml
 name: Sync to Notion
 on:
   push:
+    branches: [main]
     paths:
-      - '**.md'
+      - 'docs/**'
   workflow_dispatch:
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - name: Notion GitHub Page Sync
-        uses: fencer-security/notion-github-page-sync-action@v1
+      - uses: actions/checkout@v4
+      - name: Sync docs to Notion
+        uses: Fencer-Security/nogisync@v1.2.0
         with:
           notion_api_key: ${{ secrets.NOTION_API_KEY }}
-          notion_parent_page_id: 'your-parent-page-id'
-          docs_path: 'docs/'  # Directory containing markdown files
+          notion_parent_page_id: ${{ secrets.NOTION_PARENT_PAGE_ID }}
+          docs_path: 'docs/'
+```
+
+Multiple directories can be synced using a YAML list:
+
+```yaml
+          docs_path:
+            - docs/
+            - guides/
+```
+
+### CLI
+
+nogisync can also be used directly from the command line:
+
+```bash
+nogisync --token $NOTION_API_KEY --parent-page-id $PAGE_ID --path docs/
+```
+
+Multiple directories:
+
+```bash
+nogisync --token $NOTION_API_KEY --parent-page-id $PAGE_ID --path "docs/,guides/"
 ```
 
 ## Configuration Options
@@ -57,9 +82,23 @@ jobs:
 |-------|-------------|----------|---------|
 | `notion_api_key` | Notion API key for authentication | Yes | - |
 | `notion_parent_page_id` | ID of the parent page in Notion | Yes | - |
-| `docs_path` | Path to directory containing markdown files | No | `.` |
-| `sync_method` | Sync method: `blocks` (convert to Notion blocks) or `markdown` (use Notion markdown API) | No | `blocks` |
+| `docs_path` | Path(s) to directories containing markdown files (YAML list, newline-separated, or comma-separated) | Yes | - |
+| `sync_method` | Sync method: `markdown` (Notion markdown API) or `blocks` (convert to Notion blocks) | No | `markdown` |
 | `fail_on_error` | Fail the action if any page fails to sync | No | `false` |
+
+### Frontmatter
+
+Pages use YAML frontmatter to set the Notion page title:
+
+```markdown
+---
+title: My Page Title
+---
+
+# Content starts here
+```
+
+If no frontmatter is present, the filename is used as the title (e.g., `getting-started.md` becomes "Getting Started").
 
 ## Example Directory Structure
 
@@ -87,14 +126,6 @@ Parent Page
 └── README
 ```
 
-## Contributing
-
-Contributions are welcome! Please feel free to submit a Pull Request.
-
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Support
-
-If you encounter any issues or have questions, please file an issue on the GitHub repository. 

--- a/action.yaml
+++ b/action.yaml
@@ -10,7 +10,7 @@ inputs:
     description: 'Notion integration token'
     required: true
   docs_path:
-    description: 'Directory containing the markdown files to sync'
+    description: 'Directory containing the markdown files to sync (YAML list, newline-separated, or comma-separated for multiple directories)'
     required: true
   notion_parent_page_id:
     description: 'Notion parent page id'
@@ -18,7 +18,7 @@ inputs:
   sync_method:
     description: "Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)"
     required: false
-    default: 'blocks'
+    default: 'markdown'
   fail_on_error:
     description: 'Fail the action if any page fails to sync'
     required: false

--- a/src/nogisync/cli.py
+++ b/src/nogisync/cli.py
@@ -61,7 +61,7 @@ def sync_file(
     provenance: bool,
     provenance_source_url: str | None,
     provenance_timestamp: bool,
-    sync_method: str = "blocks",
+    sync_method: str = "markdown",
     markdown_client=None,
 ) -> None:
     """Sync a single markdown file to Notion."""
@@ -112,8 +112,8 @@ def sync_file(
 @click.option(
     "--path",
     "-p",
-    type=click.Path(exists=True, file_okay=False, readable=True, resolve_path=True, path_type=Path),
-    help="Path to the markdown files",
+    type=str,
+    help="Path(s) to directories containing markdown files (comma-separated for multiple)",
 )
 @click.option(
     "--provenance/--no-provenance",
@@ -134,7 +134,7 @@ def sync_file(
 @click.option(
     "--sync-method",
     type=click.Choice(["blocks", "markdown"], case_sensitive=False),
-    default="blocks",
+    default="markdown",
     help="Sync method: 'blocks' (convert to Notion blocks) or 'markdown' (use Notion markdown API)",
 )
 @click.option(
@@ -152,7 +152,7 @@ def sync_file(
 def main(
     token: str,
     parent_page_id: str,
-    path: Path,
+    path: str,
     provenance: bool,
     provenance_source_url: str | None,
     provenance_timestamp: bool,
@@ -165,8 +165,16 @@ def main(
     """
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
 
-    markdown_files = list(Path(path).rglob("*.md"))
-    logger.info("Found %d markdown files to sync", len(markdown_files))
+    # Resolve paths (comma-separated for multiple directories)
+    paths = resolve_paths(path)
+
+    # Collect markdown files from all paths, tracking each file's base directory
+    file_entries: list[tuple[Path, Path]] = []
+    for base_path in paths:
+        for md_file in base_path.rglob("*.md"):
+            file_entries.append((md_file, base_path))
+
+    logger.info("Found %d markdown files to sync across %d directories", len(file_entries), len(paths))
     start = time.monotonic()
 
     client = notion.get_notion_client(token)
@@ -174,26 +182,28 @@ def main(
 
     # Pre-resolve directory hierarchies sequentially (they depend on parent IDs)
     hierarchy_cache: dict[str, str] = {}
-    for md_file in markdown_files:
-        relative_path = md_file.relative_to(path)
+    for md_file, base_path in file_entries:
+        relative_path = md_file.relative_to(base_path)
         process_page_hierarchy(client, parent_page_id, relative_path, hierarchy_cache)
 
     # Build a map of each file to its resolved parent page ID
     file_parent_ids: dict[Path, str] = {}
-    for md_file in markdown_files:
-        relative_path = md_file.relative_to(path)
+    for md_file, base_path in file_entries:
+        relative_path = md_file.relative_to(base_path)
         dir_key = str(relative_path.parent)
         file_parent_ids[md_file] = hierarchy_cache.get(dir_key, parent_page_id)
 
     # Sync files in parallel
     failed = []
+    # Build a lookup from md_file → base_path for error reporting
+    file_base_paths = {md_file: base_path for md_file, base_path in file_entries}
     with ThreadPoolExecutor(max_workers=workers) as executor:
         futures = {
             executor.submit(
                 sync_file,
                 client,
                 md_file,
-                path,
+                base_path,
                 file_parent_ids[md_file],
                 provenance,
                 provenance_source_url,
@@ -201,21 +211,74 @@ def main(
                 sync_method,
                 markdown_client,
             ): md_file
-            for md_file in markdown_files
+            for md_file, base_path in file_entries
         }
         for future in as_completed(futures):
             md_file = futures[future]
             try:
                 future.result()
             except Exception:
-                logger.exception("Failed to sync %s", md_file.relative_to(path))
+                logger.exception("Failed to sync %s", md_file.relative_to(file_base_paths[md_file]))
                 failed.append(md_file)
 
     elapsed = time.monotonic() - start
-    logger.info("Sync complete: %d files in %.1fs (%d failed)", len(markdown_files), elapsed, len(failed))
+    logger.info("Sync complete: %d files in %.1fs (%d failed)", len(file_entries), elapsed, len(failed))
 
     if failed and fail_on_error:
         raise SystemExit(1)
+
+
+def resolve_paths(path_str: str) -> list[Path]:
+    """Parse path string into resolved Path objects.
+
+    Supports multiple formats for GitHub Actions compatibility:
+
+        # Single path
+        docs_path: docs/
+
+        # YAML list (serialized as JSON array by GitHub Actions)
+        docs_path:
+          - docs/
+          - guides/
+
+        # Multiline string with YAML-style bullets
+        docs_path: |
+          - docs/
+          - guides/
+
+        # Newline-separated
+        docs_path: |
+          docs/
+          guides/
+
+        # Comma-separated
+        docs_path: 'docs/,guides/'
+    """
+    stripped = path_str.strip()
+
+    # Handle JSON array format: ["docs/", "guides/"]
+    if stripped.startswith("["):
+        try:
+            import json
+
+            parsed = json.loads(stripped)
+            raw_paths = [str(p).strip() for p in parsed if str(p).strip()] if isinstance(parsed, list) else [stripped]
+        except json.JSONDecodeError, ValueError:
+            raw_paths = [stripped]
+    else:
+        # Split on commas and newlines, strip YAML list bullet prefixes
+        raw_paths = [re.sub(r"^-\s+", "", p.strip()) for p in re.split(r"[,\n]", stripped) if p.strip()]
+    if not raw_paths:
+        raise click.BadParameter("At least one path is required", param_hint="'--path'")
+    resolved = []
+    for raw in raw_paths:
+        p = Path(raw).resolve()
+        if not p.exists():
+            raise click.BadParameter(f"Path does not exist: {raw}", param_hint="'--path'")
+        if not p.is_dir():
+            raise click.BadParameter(f"Path is not a directory: {raw}", param_hint="'--path'")
+        resolved.append(p)
+    return resolved
 
 
 _FRONTMATTER_RE = re.compile(r"^\s*(?:---|\+\+\+)(.*?)(?:---|\+\+\+)\s*(.+)$", re.DOTALL)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,9 +2,18 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
+import click
 from click.testing import CliRunner
 
-from nogisync.cli import get_content, get_title, main, process_page_hierarchy, read_frontmatter, sync_file
+from nogisync.cli import (
+    get_content,
+    get_title,
+    main,
+    process_page_hierarchy,
+    read_frontmatter,
+    resolve_paths,
+    sync_file,
+)
 
 
 class TestGetTitle(TestCase):
@@ -53,6 +62,84 @@ class TestReadFrontmatter(TestCase):
             Path("test.md").write_text("---\n: invalid: yaml: {{{\n---\nBody")
             with self.assertRaises(yaml.YAMLError):
                 read_frontmatter(Path("test.md"))
+
+
+class TestResolvePaths(TestCase):
+    def test_single_path(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            paths = resolve_paths("docs")
+            self.assertEqual(len(paths), 1)
+
+    def test_comma_separated_paths(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            paths = resolve_paths("docs,guides")
+            self.assertEqual(len(paths), 2)
+
+    def test_comma_separated_with_spaces(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            paths = resolve_paths("docs, guides")
+            self.assertEqual(len(paths), 2)
+
+    def test_newline_separated_paths(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            paths = resolve_paths("docs\nguides\n")
+            self.assertEqual(len(paths), 2)
+
+    def test_mixed_comma_and_newline(self):
+        with CliRunner().isolated_filesystem():
+            Path("a").mkdir()
+            Path("b").mkdir()
+            Path("c").mkdir()
+            paths = resolve_paths("a,b\nc")
+            self.assertEqual(len(paths), 3)
+
+    def test_json_array_format(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            paths = resolve_paths('["docs", "guides"]')
+            self.assertEqual(len(paths), 2)
+
+    def test_yaml_bullet_list(self):
+        with CliRunner().isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            paths = resolve_paths("- docs\n- guides")
+            self.assertEqual(len(paths), 2)
+
+    def test_json_non_list_falls_back(self):
+        with CliRunner().isolated_filesystem():
+            # JSON parses as a dict, not a list — treated as raw path string
+            with self.assertRaises(click.BadParameter):
+                resolve_paths('{"key": "value"}')
+
+    def test_invalid_json_with_bracket_prefix(self):
+        with CliRunner().isolated_filesystem():
+            Path("[notjson").mkdir()
+            paths = resolve_paths("[notjson")
+            self.assertEqual(len(paths), 1)
+
+    def test_file_path_raises(self):
+        with CliRunner().isolated_filesystem():
+            Path("afile.txt").write_text("hi")
+            with self.assertRaises(click.BadParameter):
+                resolve_paths("afile.txt")
+
+    def test_nonexistent_path_raises(self):
+        with CliRunner().isolated_filesystem():
+            with self.assertRaises(click.BadParameter):
+                resolve_paths("nonexistent")
+
+    def test_empty_path_raises(self):
+        with self.assertRaises(click.BadParameter):
+            resolve_paths("")
 
 
 class TestProcessPageHierarchy(TestCase):
@@ -126,7 +213,9 @@ class TestSyncFile(TestCase):
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nContent")
-            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
+            sync_file(
+                MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True, sync_method="blocks"
+            )
 
         mock_notion.create_notion_page.assert_called_once()
 
@@ -137,7 +226,9 @@ class TestSyncFile(TestCase):
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\ntitle: Test Doc\n---\nUpdated content")
-            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
+            sync_file(
+                MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True, sync_method="blocks"
+            )
 
         mock_notion.update_notion_page.assert_called_once()
 
@@ -149,7 +240,9 @@ class TestSyncFile(TestCase):
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("# No frontmatter\nJust content")
-            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
+            sync_file(
+                MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True, sync_method="blocks"
+            )
 
         mock_notion.create_notion_page.assert_called_once()
 
@@ -161,7 +254,9 @@ class TestSyncFile(TestCase):
         with CliRunner().isolated_filesystem():
             Path("docs").mkdir()
             Path("docs/test.md").write_text("---\n: invalid: yaml: {{{\n---\nBody content")
-            sync_file(MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True)
+            sync_file(
+                MagicMock(), Path("docs/test.md"), Path("docs"), "parent-id", True, None, True, sync_method="blocks"
+            )
 
         mock_notion.create_notion_page.assert_called_once()
 
@@ -267,8 +362,9 @@ class TestMain(TestCase):
     def test_syncs_files_in_parallel(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.get_notion_markdown_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
-        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+        mock_notion.create_notion_page_markdown.return_value = {"id": "new-page"}
 
         with runner.isolated_filesystem():
             Path("docs").mkdir()
@@ -277,7 +373,7 @@ class TestMain(TestCase):
             result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
 
         self.assertEqual(result.exit_code, 0)
-        self.assertEqual(mock_notion.create_notion_page.call_count, 2)
+        self.assertEqual(mock_notion.create_notion_page_markdown.call_count, 2)
 
     @patch("nogisync.cli.notion")
     def test_with_subdirectories(self, mock_notion):
@@ -330,11 +426,12 @@ class TestMain(TestCase):
         mock_notion.create_notion_page.assert_not_called()
 
     @patch("nogisync.cli.notion")
-    def test_default_sync_method_is_blocks(self, mock_notion):
+    def test_default_sync_method_is_markdown(self, mock_notion):
         runner = CliRunner()
         mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.get_notion_markdown_client.return_value = MagicMock()
         mock_notion.find_notion_page.return_value = None
-        mock_notion.create_notion_page.return_value = {"id": "new-page"}
+        mock_notion.create_notion_page_markdown.return_value = {"id": "new-page"}
 
         with runner.isolated_filesystem():
             Path("docs").mkdir()
@@ -342,8 +439,26 @@ class TestMain(TestCase):
             result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs"])
 
         self.assertEqual(result.exit_code, 0)
-        mock_notion.create_notion_page.assert_called_once()
-        mock_notion.create_notion_page_markdown.assert_not_called()
+        mock_notion.create_notion_page_markdown.assert_called_once()
+        mock_notion.create_notion_page.assert_not_called()
+
+    @patch("nogisync.cli.notion")
+    def test_multiple_directories(self, mock_notion):
+        runner = CliRunner()
+        mock_notion.get_notion_client.return_value = MagicMock()
+        mock_notion.get_notion_markdown_client.return_value = MagicMock()
+        mock_notion.find_notion_page.return_value = None
+        mock_notion.create_notion_page_markdown.return_value = {"id": "new-page"}
+
+        with runner.isolated_filesystem():
+            Path("docs").mkdir()
+            Path("guides").mkdir()
+            Path("docs/a.md").write_text("---\ntitle: Doc A\n---\nContent A")
+            Path("guides/b.md").write_text("---\ntitle: Guide B\n---\nContent B")
+            result = runner.invoke(main, ["-t", "fake-token", "-parentid", "parent-id", "-p", "docs,guides"])
+
+        self.assertEqual(result.exit_code, 0)
+        self.assertEqual(mock_notion.create_notion_page_markdown.call_count, 2)
 
     @patch("nogisync.cli.notion")
     def test_custom_workers(self, mock_notion):


### PR DESCRIPTION
## Summary

- Default `sync_method` changed from `blocks` to `markdown`
- `docs_path` / `--path` now accepts multiple directories in any of these formats:
  - YAML list: `docs_path: [docs/, guides/]`
  - Multiline with bullets: `- docs/\n- guides/`
  - Newline-separated: `docs/\nguides/`
  - Comma-separated: `docs/,guides/`
- README rewritten to reflect actual features and usage (removed inaccurate claims, added CLI docs, frontmatter docs, multi-directory examples)